### PR TITLE
getForEachChildren, getForEachChildIndex

### DIFF
--- a/src/compiler/ast/common/Node.ts
+++ b/src/compiler/ast/common/Node.ts
@@ -498,7 +498,7 @@ export class Node<NodeType extends ts.Node = ts.Node> implements TextRange {
     }
 
     /**
-     * Gets all the children of the node using `forEachChild` method to obtain the children.
+     * Gets the children of the node using `forEachChild` method to obtain the children.
      *
      * Unlike `getChildren`, it will not return all kind of children only high level ones.
      * For example, `SyntaxKind.SemicolonToken` will be omitted. If you need all kind of

--- a/src/compiler/ast/common/Node.ts
+++ b/src/compiler/ast/common/Node.ts
@@ -498,6 +498,17 @@ export class Node<NodeType extends ts.Node = ts.Node> implements TextRange {
     }
 
     /**
+     * Gets all the children of the node using `forEachChild` method to obtain the children.
+     *
+     * Unlike `getChildren`, it will not return all kind of children only high level ones.
+     * For example, `SyntaxKind.SemicolonToken` will be omitted. If you need all kind of
+     * children then use `getChildren` method.
+     */
+    getForEachChildren(): Node[] {
+        return this._getCompilerForEachChildren().map(n => this._getNodeFromCompilerNode(n));
+    }
+
+    /**
      * Gets the child at the specified index.
      * @param index - Index of the child.
      */
@@ -1125,12 +1136,28 @@ export class Node<NodeType extends ts.Node = ts.Node> implements TextRange {
     }
 
     /**
-     * Gets the child index of this node relative to the parent.
+     * Gets the child index of this node relative to its parent, obtaining children using `getChildren` method.
      */
     getChildIndex() {
         const parent = this.getParentSyntaxList() || this.getParentOrThrow();
         let i = 0;
         for (const child of parent._getCompilerChildren()) {
+            if (child === this.compilerNode)
+                return i;
+            i++;
+        }
+
+        /* istanbul ignore next */
+        throw new errors.NotImplementedError("For some reason the child's parent did not contain the child.");
+    }
+
+    /**
+     * Gets the child index of this node relative to its parent, obtaining children using `getForEachChild` method.
+     */
+    getForEachChildIndex() {
+        const parent = this.getParentSyntaxList() || this.getParentOrThrow();
+        let i = 0;
+        for (const child of parent._getCompilerForEachChildren()) {
             if (child === this.compilerNode)
                 return i;
             i++;

--- a/src/compiler/ast/common/Node.ts
+++ b/src/compiler/ast/common/Node.ts
@@ -1152,7 +1152,7 @@ export class Node<NodeType extends ts.Node = ts.Node> implements TextRange {
     }
 
     /**
-     * Gets the child index of this node relative to its parent, obtaining children using `getForEachChild` method.
+     * Gets the child index of this node relative to its parent, obtaining children using `getForEachChildren` method.
      */
     getForEachChildIndex() {
         const parent = this.getParentSyntaxList() || this.getParentOrThrow();

--- a/src/tests/compiler/ast/common/nodeTests.ts
+++ b/src/tests/compiler/ast/common/nodeTests.ts
@@ -220,6 +220,43 @@ describe(nameof(Node), () => {
         });
     });
 
+    describe(nameof<Node>(n => n.getChildren), () => {
+        const { sourceFile } = getInfoFromText("var a = 1;");
+        const variable = sourceFile.getVariableDeclarationOrThrow("a");
+
+        it("should get children of tall kinds", () => {
+            expect(variable.getChildren().map(c => c.getKindName())).to.deep.equal(["Identifier", "EqualsToken", "NumericLiteral"]);
+        });
+    });
+
+    describe(nameof<Node>(n => n.getForEachChildren), () => {
+        const { sourceFile } = getInfoFromText("var a = 1");
+        const variable = sourceFile.getVariableDeclarationOrThrow("a");
+
+        it("should get children of the same kind as visited with forEachChild method", () => {
+            expect(variable.getForEachChildren().map(c => c.getKindName())).to.deep.equal(["Identifier", "NumericLiteral"]);
+        });
+    });
+
+    describe(nameof<Node>(n => n.getChildIndex), () => {
+        const { sourceFile } = getInfoFromText("var a = 1;");
+        const value = sourceFile.getVariableDeclarationOrThrow("a").getLastChildByKindOrThrow(SyntaxKind.NumericLiteral);
+
+        it("should get the child index of this node relative to the parent obtaining children using `getChildren` method.", () => {
+
+            expect(value.getChildIndex()).to.equal(2);
+        });
+    });
+
+    describe(nameof<Node>(n => n.getForEachChildIndex), () => {
+        const { sourceFile } = getInfoFromText("var a = 1");
+        const value = sourceFile.getVariableDeclarationOrThrow("a").getLastChildByKindOrThrow(SyntaxKind.NumericLiteral);
+
+        it("should get the child index of this node relative to the parent obtaining children using `getForEachChild` method", () => {
+            expect(value.getForEachChildIndex()).to.equal(1);
+        });
+    });
+
     describe(nameof<Node>(n => n.getParentSyntaxList), () => {
         it("should return undefined for an end of file token", () => {
             const { sourceFile } = getInfoFromText("class C {}");


### PR DESCRIPTION
 * Adds getForEachChildren method to Node returning children using forEachChild since it's most likely useful than getChildren.  Using already existing implementation
 * adds getForEachChildIndex method to node, analog to getChildIndex. 
 * adds simple tests for getChildren, getChildIndex, getForEachChildren and getForEachChildIndex 

Sorry for not create an issue to discuss first, was simpler for me to just create the PR, feel free to close / discuss here

Thanks