### PR TITLE
Add getParentIf(OrThrow)

### DIFF
--- a/src/compiler/ast/common/Node.ts
+++ b/src/compiler/ast/common/Node.ts
@@ -1643,20 +1643,43 @@ export class Node<NodeType extends ts.Node = ts.Node> {
         const nextSibling = this._getCompilerNextSibling();
         return nextSibling != null && nextSibling.kind === kind ? (this._getNodeFromCompilerNode(nextSibling) as KindToNodeMappings[TKind]) : undefined;
     }
+    
+    /**
+     * Gets the parent if it matches a certain condition or throws
+     */
+    getParentIfOrThrow<T extends Node>(condition: (parent: Node | undefined, node: Node) => parent is T): T;
+    /**
+     * Gets the parent if it matches a certain condition or throws
+     */
+    getParentIfOrThrow(condition: (parent: Node | undefined, node: Node) => boolean): Node;
+    getParentIfOrThrow(condition: (parent: Node | undefined, node: Node) => boolean) {
+        return errors.throwIfNullOrUndefined(this.getParentIf(condition), "The parent did not match the provided condition.");
+    }
+
+    /**
+     * Gets the parent if it matches a certain condition.
+     */
+    getParentIf<T extends Node>(condition: (parent: Node | undefined, node: Node) => parent is T): T | undefined;
+    /**
+     * Gets the parent if it matches a certain condition.
+     */
+    getParentIf(condition: (parent: Node | undefined, node: Node) => boolean): Node | undefined;
+    getParentIf(condition: (parent: Node | undefined, node: Node) => boolean) {
+        return condition(this.getParent(), this) ? this.getParent() : undefined;
+    }
+
+    /**
+     * Gets the parent if it's a certain syntax kind or throws.
+     */
+    getParentIfKindOrThrow<TKind extends SyntaxKind>(kind: TKind): KindToNodeMappings[TKind] {
+        return errors.throwIfNullOrUndefined(this.getParentIfKind(kind), `The parent was not a syntax kind of ${getSyntaxKindName(kind)}.`);
+    }
 
     /**
      * Gets the parent if it's a certain syntax kind.
      */
     getParentIfKind<TKind extends SyntaxKind>(kind: TKind): KindToNodeMappings[TKind] | undefined {
-        const parentNode = this.getParent();
-        return parentNode == null || parentNode.getKind() !== kind ? undefined : (parentNode as KindToNodeMappings[TKind]);
-    }
-
-    /**
-     * Gets the parent if it's a certain syntax kind of throws.
-     */
-    getParentIfKindOrThrow<TKind extends SyntaxKind>(kind: TKind): KindToNodeMappings[TKind] {
-        return errors.throwIfNullOrUndefined(this.getParentIfKind(kind), `Expected a parent with a syntax kind of ${getSyntaxKindName(kind)}.`);
+        return this.getParentIf(n => n !== undefined && n.getKind() === kind) as KindToNodeMappings[TKind] | undefined;
     }
 
     /**

--- a/src/tests/compiler/ast/common/nodeTests.ts
+++ b/src/tests/compiler/ast/common/nodeTests.ts
@@ -514,7 +514,33 @@ class MyClass {
         it("should have the correct type when it's a source file", () => {
             assert<IsExact<NodeParentType<ts.SourceFile>, undefined>>(true);
         });
+	});
+
+	describe(nameof<Node>(n => n.getParentIf), () => {
+        const { firstChild } = getInfoFromText<ClassDeclaration>("export class Identifier { prop: string; }");
+        const child = firstChild.getInstanceProperty("prop")!;
+
+        it("should get the parent when it matches the condition", () => {
+            expect(child.getParentIf(n => n !== undefined && n.getKind() === SyntaxKind.ClassDeclaration)).to.not.be.undefined;
+        });
+
+        it("should not get the parent when doesn't match the condition", () => {
+            expect(child.getParentIf(n => n !== undefined && n.getKind() === SyntaxKind.InterfaceDeclaration)).to.be.undefined;
+        });
     });
+
+    describe(nameof<Node>(n => n.getParentIfOrThrow), () => {
+        const { firstChild } = getInfoFromText<ClassDeclaration>("export class Identifier { prop: string; }");
+        const child = firstChild.getInstanceProperty("prop")!;
+
+        it("should get the parent when it matches the condition", () => {
+            expect(child.getParentIfOrThrow(n => n !== undefined && n.getKind() === SyntaxKind.ClassDeclaration)).to.not.be.undefined;
+        });
+
+        it("should throw when the parent doesn't match the condition", () => {
+            expect(() => child.getParentIfOrThrow(n => n !== undefined && n.getKind() === SyntaxKind.InterfaceDeclaration)).to.throw();
+        });
+	});
 
     describe(nameof<Node>(n => n.getParentIfKind), () => {
         const { firstChild } = getInfoFromText<ClassDeclaration>("export class Identifier { prop: string; }");
@@ -537,10 +563,10 @@ class MyClass {
             expect(child.getParentIfKindOrThrow(SyntaxKind.ClassDeclaration)).to.not.be.undefined;
         });
 
-        it("should throw when it's not the right kind", () => {
+        it("should throw when the parent is not the right kind", () => {
             expect(() => child.getParentIfKindOrThrow(SyntaxKind.InterfaceDeclaration)).to.throw();
         });
-    });
+	});
 
     describe(nameof<Node>(n => n.getParentWhile), () => {
         it("should keep getting the parent until a condition is no longer matched", () => {


### PR DESCRIPTION
Closes #712.
I used the same overloads as `getParentWhile`.

The only issue I have with this implementation is that you almost always want to check for existence, so your `condition` function will almost always be in the form of `n => n !== undefined && ...`. 
Perhaps we could add additional `getParentIfExists` and `getParentIfExistsOrThrow` functions to avoid this?