### PR TITLE
Soft rename addExistingSourceFile(s)(IfExists)

### DIFF
--- a/packages/ts-morph/src/Project.ts
+++ b/packages/ts-morph/src/Project.ts
@@ -229,9 +229,31 @@ export class Project {
      * Adds source files based on file globs.
      * @param fileGlobs - File glob or globs to add files based on.
      * @returns The matched source files.
+     * @deprecated Use `addSourceFilesAtPaths`.
      */
     addExistingSourceFiles(fileGlobs: string | ReadonlyArray<string>): SourceFile[] {
-        return this._context.directoryCoordinator.addExistingSourceFiles(fileGlobs, { markInProject: true });
+        return this.addSourceFilesAtPaths(fileGlobs);
+    }
+
+    /**
+     * Adds source files based on file globs.
+     * @param fileGlobs - File glob or globs to add files based on.
+     * @returns The matched source files.
+     */
+    addSourceFilesAtPaths(fileGlobs: string | ReadonlyArray<string>): SourceFile[] {
+        return this._context.directoryCoordinator.addSourceFilesAtPaths(fileGlobs, { markInProject: true });
+    }
+
+    /**
+     * Adds a source file from a file path if it exists or returns undefined.
+     *
+     * Will return the source file if it was already added.
+     * @param filePath - File path to get the file from.
+     * @skipOrThrowCheck
+     * @deprecated Use `addSourceFileAtPathIfExists`.
+     */
+    addExistingSourceFileIfExists(filePath: string): SourceFile | undefined {
+        return this.addSourceFileAtPathIfExists(filePath);
     }
 
     /**
@@ -241,8 +263,20 @@ export class Project {
      * @param filePath - File path to get the file from.
      * @skipOrThrowCheck
      */
-    addExistingSourceFileIfExists(filePath: string): SourceFile | undefined {
-        return this._context.directoryCoordinator.addExistingSourceFileIfExists(filePath, { markInProject: true });
+    addSourceFileAtPathIfExists(filePath: string): SourceFile | undefined {
+        return this._context.directoryCoordinator.addSourceFileAtPathIfExists(filePath, { markInProject: true });
+    }
+
+    /**
+     * Adds an existing source file from a file path or throws if it doesn't exist.
+     *
+     * Will return the source file if it was already added.
+     * @param filePath - File path to get the file from.
+     * @throws FileNotFoundError when the file is not found.
+     * @deprecated Use `addSourceFileAtPath`.
+     */
+    addExistingSourceFile(filePath: string): SourceFile {
+        return this.addSourceFileAtPath(filePath);
     }
 
     /**
@@ -252,8 +286,8 @@ export class Project {
      * @param filePath - File path to get the file from.
      * @throws FileNotFoundError when the file is not found.
      */
-    addExistingSourceFile(filePath: string): SourceFile {
-        return this._context.directoryCoordinator.addExistingSourceFile(filePath, { markInProject: true });
+    addSourceFileAtPath(filePath: string): SourceFile {
+        return this._context.directoryCoordinator.addSourceFileAtPath(filePath, { markInProject: true });
     }
 
     /**

--- a/packages/ts-morph/src/Project.ts
+++ b/packages/ts-morph/src/Project.ts
@@ -307,7 +307,7 @@ export class Project {
     private _addSourceFilesForTsConfigResolver(tsConfigResolver: TsConfigResolver, compilerOptions: CompilerOptions) {
         const paths = tsConfigResolver.getPaths(compilerOptions);
 
-        const addedSourceFiles = paths.filePaths.map(p => this.addExistingSourceFile(p));
+        const addedSourceFiles = paths.filePaths.map(p => this.addSourceFileAtPath(p));
         for (const dirPath of paths.directoryPaths)
             this.addExistingDirectoryIfExists(dirPath);
         return addedSourceFiles;

--- a/packages/ts-morph/src/fileSystem/Directory.ts
+++ b/packages/ts-morph/src/fileSystem/Directory.ts
@@ -240,8 +240,18 @@ export class Directory {
      * Add source files based on file globs.
      * @param fileGlobs - File glob or globs to add files based on.
      * @returns The matched source files.
+     * @deprecated Use `addSourceFilesAtPaths`.
      */
     addExistingSourceFiles(fileGlobs: string | ReadonlyArray<string>): SourceFile[] {
+        return this.addSourceFilesAtPaths(fileGlobs);
+    }
+
+    /**
+     * Add source files based on file globs.
+     * @param fileGlobs - File glob or globs to add files based on.
+     * @returns The matched source files.
+     */
+    addSourceFilesAtPaths(fileGlobs: string | ReadonlyArray<string>): SourceFile[] {
         fileGlobs = typeof fileGlobs === "string" ? [fileGlobs] : fileGlobs;
         fileGlobs = fileGlobs.map(g => {
             if (FileUtils.pathIsAbsolute(g))
@@ -250,7 +260,7 @@ export class Directory {
             return FileUtils.pathJoin(this.getPath(), g);
         });
 
-        return this._context.directoryCoordinator.addExistingSourceFiles(fileGlobs, { markInProject: this._isInProject() });
+        return this._context.directoryCoordinator.addSourceFilesAtPaths(fileGlobs, { markInProject: this._isInProject() });
     }
 
     /**
@@ -317,10 +327,34 @@ export class Directory {
      * Will return the source file if it was already added.
      * @param relativeFilePath - Relative file path to add.
      * @skipOrThrowCheck
+     * @deprecated Use `addSourceFileAtPathIfExists`.
      */
     addExistingSourceFileIfExists(relativeFilePath: string): SourceFile | undefined {
+        return this.addSourceFileAtPathIfExists(relativeFilePath);
+    }
+
+    /**
+     * Adds an existing source file, relative to this directory, or returns undefined.
+     *
+     * Will return the source file if it was already added.
+     * @param relativeFilePath - Relative file path to add.
+     * @skipOrThrowCheck
+     */
+    addSourceFileAtPathIfExists(relativeFilePath: string): SourceFile | undefined {
         const filePath = this._context.fileSystemWrapper.getStandardizedAbsolutePath(relativeFilePath, this.getPath());
-        return this._context.directoryCoordinator.addExistingSourceFileIfExists(filePath, { markInProject: this._isInProject() });
+        return this._context.directoryCoordinator.addSourceFileAtPathIfExists(filePath, { markInProject: this._isInProject() });
+    }
+
+    /**
+     * Adds an existing source file, relative to this directory, or throws if it doesn't exist.
+     *
+     * Will return the source file if it was already added.
+     * @param relativeFilePath - Relative file path to add.
+     * @throws FileNotFoundError when the file doesn't exist.
+     * @deprecated Use `addSourceFileAtPath`.
+     */
+    addExistingSourceFile(relativeFilePath: string): SourceFile {
+        return this.addSourceFileAtPath(relativeFilePath);
     }
 
     /**
@@ -330,9 +364,9 @@ export class Directory {
      * @param relativeFilePath - Relative file path to add.
      * @throws FileNotFoundError when the file doesn't exist.
      */
-    addExistingSourceFile(relativeFilePath: string): SourceFile {
+    addSourceFileAtPath(relativeFilePath: string): SourceFile {
         const filePath = this._context.fileSystemWrapper.getStandardizedAbsolutePath(relativeFilePath, this.getPath());
-        return this._context.directoryCoordinator.addExistingSourceFile(filePath, { markInProject: this._isInProject() });
+        return this._context.directoryCoordinator.addSourceFileAtPath(filePath, { markInProject: this._isInProject() });
     }
 
     /**

--- a/packages/ts-morph/src/fileSystem/DirectoryCoordinator.ts
+++ b/packages/ts-morph/src/fileSystem/DirectoryCoordinator.ts
@@ -36,21 +36,21 @@ export class DirectoryCoordinator {
         return this.compilerFactory.createDirectoryOrAddIfExists(dirPath, options);
     }
 
-    addExistingSourceFileIfExists(filePath: string, options: { markInProject: boolean; }): SourceFile | undefined {
+    addSourceFileAtPathIfExists(filePath: string, options: { markInProject: boolean; }): SourceFile | undefined {
         return this.compilerFactory.addOrGetSourceFileFromFilePath(filePath, {
             markInProject: options.markInProject,
             scriptKind: undefined
         });
     }
 
-    addExistingSourceFile(filePath: string, options: { markInProject: boolean; }): SourceFile {
-        const sourceFile = this.addExistingSourceFileIfExists(filePath, options);
+    addSourceFileAtPath(filePath: string, options: { markInProject: boolean; }): SourceFile {
+        const sourceFile = this.addSourceFileAtPathIfExists(filePath, options);
         if (sourceFile == null)
             throw new errors.FileNotFoundError(this.fileSystemWrapper.getStandardizedAbsolutePath(filePath));
         return sourceFile;
     }
 
-    addExistingSourceFiles(fileGlobs: string | ReadonlyArray<string>, options: { markInProject: boolean; }): SourceFile[] {
+    addSourceFilesAtPaths(fileGlobs: string | ReadonlyArray<string>, options: { markInProject: boolean; }): SourceFile[] {
         if (typeof fileGlobs === "string")
             fileGlobs = [fileGlobs];
 
@@ -58,7 +58,7 @@ export class DirectoryCoordinator {
         const globbedDirectories = FileUtils.getParentMostPaths(fileGlobs.filter(g => !FileUtils.isNegatedGlob(g)).map(g => FileUtils.getGlobDir(g)));
 
         for (const filePath of this.fileSystemWrapper.glob(fileGlobs)) {
-            const sourceFile = this.addExistingSourceFileIfExists(filePath, options);
+            const sourceFile = this.addSourceFileAtPathIfExists(filePath, options);
             if (sourceFile != null)
                 sourceFiles.push(sourceFile);
         }

--- a/packages/ts-morph/src/tests/compiler/tools/results/memoryEmitResultTests.ts
+++ b/packages/ts-morph/src/tests/compiler/tools/results/memoryEmitResultTests.ts
@@ -7,7 +7,7 @@ describe(nameof(MemoryEmitResult), () => {
         const project = new Project({ compilerOptions, useVirtualFileSystem: true });
         const fileSystem = project.getFileSystem();
         fileSystem.writeFileSync("file1.ts", "\uFEFFconst num1 = 1;"); // has BOM
-        project.addExistingSourceFile("file1.ts");
+        project.addSourceFileAtPath("file1.ts");
         project.createSourceFile("file2.ts", "const num2 = 2;");
         return { project, fileSystem };
     }

--- a/packages/ts-morph/src/tests/fileSystem/directoryTests.ts
+++ b/packages/ts-morph/src/tests/fileSystem/directoryTests.ts
@@ -361,31 +361,31 @@ describe(nameof(Directory), () => {
         });
     });
 
-    describe(nameof<Directory>(d => d.addExistingSourceFileIfExists), () => {
+    describe(nameof<Directory>(d => d.addSourceFileAtPathIfExists), () => {
         it("should return undefined if adding a source file at a non-existent path", () => {
             const fileSystem = getFileSystemHostWithFiles([]);
             const project = new Project({ fileSystem });
             const directory = project.createDirectory("dir");
-            expect(directory.addExistingSourceFileIfExists("non-existent-file.ts")).to.be.undefined;
+            expect(directory.addSourceFileAtPathIfExists("non-existent-file.ts")).to.be.undefined;
         });
 
         it("should add a source file that exists", () => {
             const fileSystem = getFileSystemHostWithFiles([{ filePath: "dir/file.ts", text: "" }], ["dir"]);
             const project = new Project({ fileSystem });
             const directory = project.addExistingDirectory("dir");
-            const sourceFile = directory.addExistingSourceFileIfExists("file.ts");
+            const sourceFile = directory.addSourceFileAtPathIfExists("file.ts");
             expect(sourceFile).to.not.be.undefined;
             expect(sourceFile!.getLanguageVersion()).to.equal(ScriptTarget.Latest);
         });
     });
 
-    describe(nameof<Directory>(d => d.addExistingSourceFile), () => {
+    describe(nameof<Directory>(d => d.addSourceFileAtPath), () => {
         it("should throw an exception if adding a source file at a non-existent path", () => {
             const fileSystem = getFileSystemHostWithFiles([]);
             const project = new Project({ fileSystem });
             const directory = project.createDirectory("dir");
             expect(() => {
-                directory.addExistingSourceFile("non-existent-file.ts");
+                directory.addSourceFileAtPath("non-existent-file.ts");
             }).to.throw(errors.FileNotFoundError, `File not found: /dir/non-existent-file.ts`);
         });
 
@@ -393,34 +393,34 @@ describe(nameof(Directory), () => {
             const fileSystem = getFileSystemHostWithFiles([{ filePath: "dir/file.ts", text: "" }], ["dir"]);
             const project = new Project({ fileSystem });
             const directory = project.addExistingDirectory("dir");
-            const sourceFile = directory.addExistingSourceFile("file.ts");
+            const sourceFile = directory.addSourceFileAtPath("file.ts");
             expect(sourceFile).to.not.be.undefined;
             expect(sourceFile.getLanguageVersion()).to.equal(ScriptTarget.Latest);
         });
     });
 
-    describe(nameof<Directory>(d => d.addExistingSourceFiles), () => {
+    describe(nameof<Directory>(d => d.addSourceFilesAtPaths), () => {
         const fileSystem = getFileSystemHostWithFiles([{ filePath: "otherDir/file.ts", text: "" }, { filePath: "dir/dir1/dir1/file.ts", text: "" }],
             ["dir", "dir/dir1", "dir/dir2", "dir/dir1/dir1", "otherDir"]);
 
         it("should add source files by a relative file glob", () => {
             const project = new Project({ fileSystem });
             const directory = project.addExistingDirectory("dir");
-            const sourceFiles = directory.addExistingSourceFiles("**/*.ts");
+            const sourceFiles = directory.addSourceFilesAtPaths("**/*.ts");
             expect(sourceFiles.map(s => s.getFilePath())).to.deep.equal(["/dir/dir1/dir1/file.ts"]);
         });
 
         it("should add source files by multiple file globs", () => {
             const project = new Project({ fileSystem });
             const directory = project.addExistingDirectory("dir");
-            const sourceFiles = directory.addExistingSourceFiles(["**/*.ts", "../**/*.ts"]);
+            const sourceFiles = directory.addSourceFilesAtPaths(["**/*.ts", "../**/*.ts"]);
             expect(sourceFiles.map(s => s.getFilePath())).to.deep.equal(["/dir/dir1/dir1/file.ts", "/otherDir/file.ts"]);
         });
 
         it("should add source files by an absolute file glob", () => {
             const project = new Project({ fileSystem });
             const directory = project.addExistingDirectory("dir");
-            const sourceFiles = directory.addExistingSourceFiles("/otherDir/**/*.ts");
+            const sourceFiles = directory.addSourceFilesAtPaths("/otherDir/**/*.ts");
             expect(sourceFiles.map(s => s.getFilePath())).to.deep.equal(["/otherDir/file.ts"]);
         });
     });
@@ -1440,7 +1440,7 @@ describe(nameof(Directory), () => {
                 const project = new Project({ fileSystem });
                 const directory = project.addExistingDirectory("dir");
                 const childDir = directory.createDirectory("childDir");
-                const sourceFile = directory.addExistingSourceFile("file.ts");
+                const sourceFile = directory.addSourceFileAtPath("file.ts");
                 const otherSourceFile = project.createSourceFile("otherFile.ts");
 
                 deleteImmediately(directory, () => {

--- a/packages/ts-morph/src/tests/issues/413tests.ts
+++ b/packages/ts-morph/src/tests/issues/413tests.ts
@@ -12,7 +12,7 @@ describe("tests for issue #413", () => {
         fs.writeFileSync("/dir2/foo.ts", "");
         fs.writeFileSync("/dir2/bar.ts", "");
 
-        const sourceFiles = project.addExistingSourceFiles(["*.ts", "dir/*.ts"]);
+        const sourceFiles = project.addSourceFilesAtPaths(["*.ts", "dir/*.ts"]);
         expect(sourceFiles.length).to.equal(3); // won't get in dir2 directory
     });
 });

--- a/packages/ts-morph/src/tests/projectTests.ts
+++ b/packages/ts-morph/src/tests/projectTests.ts
@@ -279,7 +279,7 @@ describe(nameof(Project), () => {
                 "/// <reference path='node_modules/first.d.ts' />\n/// <reference path='node_modules/library/node_modules/second.d.ts' />");
 
             const project = new Project({ fileSystem });
-            project.addExistingSourceFile("/main.ts");
+            project.addSourceFileAtPath("/main.ts");
             project.resolveSourceFileDependencies();
             assertHasSourceFiles(project, ["/main.ts"]);
             assertHasDirectories(project, ["/"]);
@@ -663,47 +663,47 @@ describe(nameof(Project), () => {
         });
     });
 
-    describe(nameof<Project>(project => project.addExistingSourceFile), () => {
+    describe(nameof<Project>(project => project.addSourceFileAtPath), () => {
         it("should throw an exception if adding a source file at a non-existent path", () => {
             const fileSystem = testHelpers.getFileSystemHostWithFiles([]);
             const project = new Project({ fileSystem });
             expect(() => {
-                project.addExistingSourceFile("non-existent-file.ts");
+                project.addSourceFileAtPath("non-existent-file.ts");
             }).to.throw(errors.FileNotFoundError, `File not found: /non-existent-file.ts`);
         });
 
         it("should add a source file that exists", () => {
             const fileSystem = testHelpers.getFileSystemHostWithFiles([{ filePath: "file.ts", text: "" }]);
             const project = new Project({ fileSystem });
-            const sourceFile = project.addExistingSourceFile("file.ts");
+            const sourceFile = project.addSourceFileAtPath("file.ts");
             expect(sourceFile).to.not.be.undefined;
             expect(sourceFile.getLanguageVersion()).to.equal(ScriptTarget.Latest);
         });
     });
 
-    describe(nameof<Project>(project => project.addExistingSourceFileIfExists), () => {
+    describe(nameof<Project>(project => project.addSourceFileAtPathIfExists), () => {
         it("should return undefined if adding a source file at a non-existent path", () => {
             const project = new Project({ useVirtualFileSystem: true });
-            expect(project.addExistingSourceFileIfExists("non-existent-file.ts")).to.be.undefined;
+            expect(project.addSourceFileAtPathIfExists("non-existent-file.ts")).to.be.undefined;
         });
 
         it("should add a source file that exists", () => {
             const fileSystem = testHelpers.getFileSystemHostWithFiles([{ filePath: "file.ts", text: "" }]);
             const project = new Project({ fileSystem });
-            const sourceFile = project.addExistingSourceFileIfExists("file.ts");
+            const sourceFile = project.addSourceFileAtPathIfExists("file.ts");
             expect(sourceFile).to.not.be.undefined;
             expect(sourceFile!.getLanguageVersion()).to.equal(ScriptTarget.Latest);
         });
     });
 
-    describe(nameof<Project>(project => project.addExistingSourceFiles), () => {
+    describe(nameof<Project>(project => project.addSourceFilesAtPaths), () => {
         it("should add based on a string file glob", () => {
             const project = new Project({ useVirtualFileSystem: true });
             const fs = project.getFileSystem();
             fs.writeFileSync("file1.ts", "");
             fs.writeFileSync("dir/file.ts", "");
             fs.writeFileSync("dir/subDir/file.ts", "");
-            const result = project.addExistingSourceFiles("/dir/**/*.ts");
+            const result = project.addSourceFilesAtPaths("/dir/**/*.ts");
             const sourceFiles = project.getSourceFiles();
             expect(sourceFiles.length).to.equal(2);
             expect(result).to.deep.equal(sourceFiles);
@@ -720,7 +720,7 @@ describe(nameof(Project), () => {
             fs.writeFileSync("dir/file.ts", "");
             fs.writeFileSync("dir/file.d.ts", "");
             fs.writeFileSync("dir/subDir/file.ts", "");
-            const result = project.addExistingSourceFiles(["/dir/**/*.ts", "!/dir/**/*.d.ts"]);
+            const result = project.addSourceFilesAtPaths(["/dir/**/*.ts", "!/dir/**/*.d.ts"]);
             const sourceFiles = project.getSourceFiles();
             expect(sourceFiles.length).to.equal(2);
             expect(result).to.deep.equal(sourceFiles);
@@ -733,7 +733,7 @@ describe(nameof(Project), () => {
             const project = new Project({ useVirtualFileSystem: true });
             const fs = project.getFileSystem();
             ["/dir", "/dir2", "/dir/child", "/dir/child/grandChild", "/dir3"].forEach(d => fs.mkdir(d));
-            const result = project.addExistingSourceFiles(["/dir/**/*.ts", "!/dir2", "/dir3/**/*.ts"]);
+            const result = project.addSourceFilesAtPaths(["/dir/**/*.ts", "!/dir2", "/dir3/**/*.ts"]);
             testHelpers.testDirectoryTree(project.getDirectoryOrThrow("/dir"), {
                 directory: project.getDirectoryOrThrow("/dir"),
                 children: [{
@@ -850,7 +850,7 @@ describe(nameof(Project), () => {
         function createProject() {
             const testFilesDirPath = path.join(__dirname, "../../src/tests/testFiles");
             const project = new Project();
-            project.addExistingSourceFiles(`${testFilesDirPath}/**/*.ts`);
+            project.addSourceFilesAtPaths(`${testFilesDirPath}/**/*.ts`);
             project.createSourceFile(
                 path.join(testFilesDirPath, "variableTestFile.ts"),
                 `import * as testClasses from "./testClasses";\n\nlet myVar = new testClasses.TestClass().name;\n`


### PR DESCRIPTION
This PR contains the soft rename and deprecation of `addExistingSourceFile`, `addExistingSourceFileIfExists` and `addExistingSourceFiles`.

Closes #733 