### PR TITLE
fix: backport to 1.3.x #685 - Fix `applyTextChanges` in node 11 and 12.

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "typescript-3.1.6": "npm:typescript@3.1.6",
     "typescript-3.2.4": "npm:typescript@3.2.4",
     "typescript-3.3.1": "npm:typescript@3.3.1",
-    "typescript-3.4.1": "npm:typescript@3.4.1",
+    "typescript-3.4.5": "npm:typescript@3.4.5",
     "typescript-3.5.3": "npm:typescript@3.5.3"
   },
   "standard-version": {

--- a/package.json
+++ b/package.json
@@ -112,7 +112,8 @@
     "typescript-3.1.6": "npm:typescript@3.1.6",
     "typescript-3.2.4": "npm:typescript@3.2.4",
     "typescript-3.3.1": "npm:typescript@3.3.1",
-    "typescript-3.4.1": "npm:typescript@3.4.1"
+    "typescript-3.4.1": "npm:typescript@3.4.1",
+    "typescript-3.5.3": "npm:typescript@3.5.3"
   },
   "standard-version": {
     "tagPrefix": ""

--- a/src/manipulation/formatting/getTextFromFormattingEdits.ts
+++ b/src/manipulation/formatting/getTextFromFormattingEdits.ts
@@ -2,19 +2,19 @@
 
 export function getTextFromFormattingEdits(sourceFile: SourceFile, formattingEdits: ReadonlyArray<TextChange>) {
     // reverse the order
-    formattingEdits = [...formattingEdits].sort((a, b) => {
-        const aStart = a.getSpan().getStart();
-        const bStart = b.getSpan().getStart();
+    const reversedFormattingEdits = formattingEdits.map((edit, index) => ({ edit, index })).sort((a, b) => {
+        const aStart = a.edit.getSpan().getStart();
+        const bStart = b.edit.getSpan().getStart();
         const difference = bStart - aStart;
-
-        return difference === 0 ? 1 : difference; // reverse when equal
+        if (difference === 0)
+            return a.index < b.index ? 1 : -1;
+        return difference > 0 ? 1 : -1;
     });
+
     let text = sourceFile.getFullText();
-
-    for (const textChange of formattingEdits) {
-        const span = textChange.getSpan();
-        text = text.slice(0, span.getStart()) + textChange.getNewText() + text.slice(span.getEnd());
+    for (const { edit } of reversedFormattingEdits) {
+        const span = edit.getSpan();
+        text = text.slice(0, span.getStart()) + edit.getNewText() + text.slice(span.getEnd());
     }
-
     return text;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3954,13 +3954,13 @@ typedarray@^0.0.6:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.1.tgz#6de14e1db4b8a006ac535e482c8ba018c55f750b"
 
-"typescript-3.4.1@npm:typescript@3.4.1":
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.1.tgz#b6691be11a881ffa9a05765a205cb7383f3b63c6"
-
-"typescript@>=3.0.1 <3.6.0":
+"typescript-3.4.5@npm:typescript@3.4.5", "typescript@>=3.0.1 <3.6.0":
   version "3.4.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.5.tgz#2d2618d10bb566572b8d7aad5180d84257d70a99"
+
+"typescript-3.5.3@npm:typescript@3.5.3":
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
 
 uglify-js@^3.1.4:
   version "3.4.9"


### PR DESCRIPTION
backporting fix for sorting formatting edits from e72b124  to the 1.3.x branch and adding missing typescript-3.5.3 alias required in tests.