### PR TITLE
preserve files outside rootDirs. fix #878

### DIFF
--- a/packages/bootstrap/src/tests/projectTests.ts
+++ b/packages/bootstrap/src/tests/projectTests.ts
@@ -11,7 +11,7 @@ describe(nameof(Project), () => {
         function doTestsForProject(create: (options: ProjectOptions) => Promise<Project>) {
             it("should add the files from tsconfig.json by default with the target in the tsconfig.json", async () => {
                 const fileSystem = new InMemoryFileSystemHost({ skipLoadingLibFiles: true });
-                fileSystem.writeFileSync("tsconfig.json", `{ "compilerOptions": { "rootDir": "test", "target": "ES5" } }`);
+                fileSystem.writeFileSync("tsconfig.json", `{ "compilerOptions": { "rootDir": "test", "target": "ES5" }, "include": ["test"] }`);
                 fileSystem.writeFileSync("/otherFile.ts", "");
                 fileSystem.writeFileSync("/test/file.ts", "");
                 fileSystem.writeFileSync("/test/test2/file2.ts", "");
@@ -27,7 +27,7 @@ describe(nameof(Project), () => {
                 fileSystem.writeFileSync("/test/file.ts", "");
                 fileSystem.writeFileSync("/test/test2/file2.ts", "");
                 const project = await create({ tsConfigFilePath: "tsconfig.json", compilerOptions: { rootDir: "/test/test2" }, fileSystem });
-                expect(project.getSourceFiles().map(s => s.fileName).sort()).to.deep.equal(["/test/test2/file2.ts"].sort());
+                expect(project.getSourceFiles().map(s => s.fileName).sort()).to.deep.equal(["/otherFile.ts", "/test/file.ts", "/test/test2/file2.ts"].sort());
             });
 
             it("should not add the files from tsconfig.json when specifying not to", async () => {
@@ -377,7 +377,7 @@ describe(nameof(Project), () => {
 
             it("should add the files from tsconfig.json", async () => {
                 const fileSystem = new InMemoryFileSystemHost({ skipLoadingLibFiles: true });
-                fileSystem.writeFileSync("tsconfig.json", `{ "compilerOptions": { "rootDir": "test", "target": "ES5" }, "exclude": ["/test/exclude"] }`);
+                fileSystem.writeFileSync("tsconfig.json", `{ "compilerOptions": { "rootDir": "test", "target": "ES5" }, "include": ["test"], "exclude": ["/test/exclude"] }`);
                 fileSystem.writeFileSync("/otherFile.ts", "");
                 fileSystem.writeFileSync("/test/file.ts", "");
                 fileSystem.writeFileSync("/test/test2/file2.ts", "");

--- a/packages/common/src/tests/tsconfig/tsConfigResolverTests.ts
+++ b/packages/common/src/tests/tsconfig/tsConfigResolverTests.ts
@@ -154,7 +154,7 @@ describe(nameof(TsConfigResolver), () => {
             fs.writeFileSync("/test/file.ts", "");
             fs.writeFileSync("/test/test2/file2.ts", "");
             doTest(fs, {
-                files: ["/test/file.ts", "/test/test2/file2.ts"],
+                files: ["/otherFile.ts", "/test/file.ts", "/test/test2/file2.ts"],
                 dirs: ["/test", "/test/test2"],
             });
         });
@@ -167,7 +167,7 @@ describe(nameof(TsConfigResolver), () => {
             fs.writeFileSync("/test/test2/file2.ts", "");
             fs.writeFileSync("/test/test2/sub/file3.ts", "");
             doTest(fs, {
-                files: ["/test/test1/file1.ts", "/test/test2/file2.ts", "/test/test2/sub/file3.ts"],
+                files: ["/test/file.ts", "/test/test1/file1.ts", "/test/test2/file2.ts", "/test/test2/sub/file3.ts"],
                 dirs: ["/test/test1", "/test/test2", "/test/test2/sub"],
             });
         });
@@ -179,7 +179,7 @@ describe(nameof(TsConfigResolver), () => {
             fs.writeFileSync("/test/test1/file1.ts", "");
             fs.writeFileSync("/test/test2/file2.ts", "");
             doTest(fs, {
-                files: ["/test/test1/file1.ts", "/test/test2/file2.ts"],
+                files: ["/test/file.ts", "/test/test1/file1.ts", "/test/test2/file2.ts"],
                 dirs: ["/test/test1", "/test/test2"],
             });
         });
@@ -226,7 +226,7 @@ describe(nameof(TsConfigResolver), () => {
             fs.writeFileSync("/test/test1/file1.ts", "");
             fs.writeFileSync("/test/test2/file2.ts", "");
             doTest(fs, {
-                files: [],
+                files: ["/file1.ts", "/file2.ts"],
                 dirs: ["/test/test1", "/test/test2"],
             });
         });
@@ -238,7 +238,7 @@ describe(nameof(TsConfigResolver), () => {
             fs.writeFileSync("/test/file.ts", "");
             fs.writeFileSync("/test2/file2.ts", "");
             doTest(fs, {
-                files: ["/test/file.ts"],
+                files: ["/test/file.ts", "/test2/file2.ts"],
                 dirs: ["/test"],
             });
         });

--- a/packages/common/src/tsconfig/TsConfigResolver.ts
+++ b/packages/common/src/tsconfig/TsConfigResolver.ts
@@ -44,8 +44,8 @@ export class TsConfigResolver {
         for (let fileName of configFileContent.fileNames) {
             const filePath = fileSystem.getStandardizedAbsolutePath(fileName);
             const parentDirPath = FileUtils.getDirPath(filePath);
+            files.add(filePath);
             if (dirInProject(parentDirPath) && fileSystem.fileExistsSync(filePath)) {
-                files.add(filePath);
                 directories.add(parentDirPath);
             }
         }

--- a/packages/ts-morph/src/tests/projectTests.ts
+++ b/packages/ts-morph/src/tests/projectTests.ts
@@ -27,7 +27,7 @@ describe(nameof(Project), () => {
 
         it("should add the files from tsconfig.json by default with the target in the tsconfig.json", () => {
             const fileSystem = new InMemoryFileSystemHost({ skipLoadingLibFiles: true });
-            fileSystem.writeFileSync("tsconfig.json", `{ "compilerOptions": { "rootDir": "test", "target": "ES5" } }`);
+            fileSystem.writeFileSync("tsconfig.json", `{ "compilerOptions": { "rootDir": "test", "target": "ES5" }, "include": ["test"] }`);
             fileSystem.writeFileSync("/otherFile.ts", "");
             fileSystem.writeFileSync("/test/file.ts", "");
             fileSystem.writeFileSync("/test/test2/file2.ts", "");
@@ -43,7 +43,7 @@ describe(nameof(Project), () => {
             fileSystem.writeFileSync("/test/file.ts", "");
             fileSystem.writeFileSync("/test/test2/file2.ts", "");
             const project = new Project({ tsConfigFilePath: "tsconfig.json", compilerOptions: { rootDir: "/test/test2" }, fileSystem });
-            expect(project.getSourceFiles().map(s => s.getFilePath()).sort()).to.deep.equal(["/test/test2/file2.ts"].sort());
+            expect(project.getSourceFiles().map(s => s.getFilePath()).sort()).to.deep.equal(["/otherFile.ts", "/test/file.ts", "/test/test2/file2.ts"].sort());
         });
 
         it("should not add the files from tsconfig.json when specifying not to", () => {
@@ -669,7 +669,7 @@ describe(nameof(Project), () => {
         it("should add the files from tsconfig.json", () => {
             const fileSystem = new InMemoryFileSystemHost({ skipLoadingLibFiles: true });
             // todo: why did I need a slash at the start of `/test/exclude`?
-            fileSystem.writeFileSync("tsconfig.json", `{ "compilerOptions": { "rootDir": "test", "target": "ES5" }, "exclude": ["/test/exclude"] }`);
+            fileSystem.writeFileSync("tsconfig.json", `{ "compilerOptions": { "rootDir": "test", "target": "ES5" }, "include": ["test"], "exclude": ["/test/exclude"] }`);
             fileSystem.writeFileSync("/otherFile.ts", "");
             fileSystem.writeFileSync("/test/file.ts", "");
             fileSystem.writeFileSync("/test/test2/file2.ts", "");


### PR DESCRIPTION
https://www.typescriptlang.org/tsconfig#rootDir

>Importantly, rootDir does not affect which files become part of the compilation. It has no interaction with the include, exclude, or files tsconfig.json settings.

Neither rootDir nor rootDirs affect file inclusions. `include` is `[]` if `files` is specified, otherwise `["**/*"]`.