### PR TITLE
feat: add isKnownTypesPackageName option

### DIFF
--- a/packages/bootstrap/lib/ts-morph-bootstrap.d.ts
+++ b/packages/bootstrap/lib/ts-morph-bootstrap.d.ts
@@ -205,6 +205,7 @@ export interface ProjectOptions {
     fileSystem?: FileSystemHost;
     /** Creates a resolution host for specifying custom module and/or type reference directive resolution. */
     resolutionHost?: ResolutionHostFactory;
+    isKnownTypesPackageName?: ts.LanguageServiceHost['isKnownTypesPackageName'];
 }
 
 /** Project that holds source files. */

--- a/packages/bootstrap/src/Project.ts
+++ b/packages/bootstrap/src/Project.ts
@@ -23,6 +23,7 @@ export interface ProjectOptions {
     fileSystem?: FileSystemHost;
     /** Creates a resolution host for specifying custom module and/or type reference directive resolution. */
     resolutionHost?: ResolutionHostFactory;
+    isKnownTypesPackageName?: ts.LanguageServiceHost['isKnownTypesPackageName'];
 }
 
 /**
@@ -152,6 +153,7 @@ export class Project {
             getNewLine: () => newLineKind,
             resolutionHost: resolutionHost || {},
             getProjectVersion: () => this._sourceFileCache.getProjectVersion().toString(),
+            isKnownTypesPackageName: options.isKnownTypesPackageName
         });
         this.languageServiceHost = languageServiceHost;
         this.compilerHost = compilerHost;

--- a/packages/common/lib/ts-morph-common.d.ts
+++ b/packages/common/lib/ts-morph-common.d.ts
@@ -192,6 +192,7 @@ export interface CreateHostsOptions {
     /** Provides the current project version to be used to tell if source files have
      * changed. Provide this for a performance improvement. */
     getProjectVersion?: () => string;
+    isKnownTypesPackageName?: ts.LanguageServiceHost['isKnownTypesPackageName'];
 }
 
 /**

--- a/packages/common/src/compiler/createHosts.ts
+++ b/packages/common/src/compiler/createHosts.ts
@@ -21,14 +21,17 @@ export interface CreateHostsOptions {
     /** Provides the current project version to be used to tell if source files have
      * changed. Provide this for a performance improvement. */
     getProjectVersion?: () => string;
+    isKnownTypesPackageName?: ts.LanguageServiceHost['isKnownTypesPackageName'];
 }
+
+const returnTrue = () => true;
 
 /**
  * Creates a language service host and compiler host.
  * @param options - Options for creating the hosts.
  */
 export function createHosts(options: CreateHostsOptions) {
-    const { transactionalFileSystem, sourceFileContainer, compilerOptions, getNewLine, resolutionHost, getProjectVersion } = options;
+    const { transactionalFileSystem, sourceFileContainer, compilerOptions, getNewLine, resolutionHost, getProjectVersion, isKnownTypesPackageName } = options;
     let version = 0;
     const fileExistsSync = (path: StandardizedFilePath) =>
         sourceFileContainer.containsSourceFileAtPath(path)
@@ -65,7 +68,8 @@ export function createHosts(options: CreateHostsOptions) {
                 );
             }
         },
-        useCaseSensitiveFileNames: () => true,
+        isKnownTypesPackageName: isKnownTypesPackageName || returnTrue,
+        useCaseSensitiveFileNames: returnTrue,
         readFile: (path, encoding) => {
             const standardizedPath = transactionalFileSystem.getStandardizedAbsolutePath(path);
             if (sourceFileContainer.containsSourceFileAtPath(standardizedPath))

--- a/packages/ts-morph/lib/ts-morph.d.ts
+++ b/packages/ts-morph/lib/ts-morph.d.ts
@@ -9542,15 +9542,25 @@ export declare class Type<TType extends ts.Type = ts.Type> {
     /** Gets the string index type. */
     getStringIndexType(): Type | undefined;
     /**
-     * Gets the target type of a type reference if it exists.
+     * Returns the generic type when the type is a type reference, returns itself when it's
+     * already a generic type, or otherwise returns undefined.
      *
-     * For example, given `Promise<string>` this will return `Promise<T>`.
+     * For example:
+     *
+     * - Given type reference `Promise<string>` returns `Promise<T>`.
+     * - Given generic type `Promise<T>` returns the same `Promise<T>`.
+     * - Given `string` returns `undefined`.
      */
     getTargetType(): Type<ts.GenericType> | undefined;
     /**
-     * Gets the target type of a type reference or throws if it doesn't exist.
+     * Returns the generic type when the type is a type reference, returns itself when it's
+     * already a generic type, or otherwise throws an error.
      *
-     * For example, given `Promise<string>` this will return `Promise<T>`.
+     * For example:
+     *
+     * - Given type reference `Promise<string>` returns `Promise<T>`.
+     * - Given generic type `Promise<T>` returns the same `Promise<T>`.
+     * - Given `string` throws an error.
      */
     getTargetTypeOrThrow(): Type<ts.GenericType>;
     /** Gets type arguments. */


### PR DESCRIPTION
This PR is to fix this [problem](https://github.com/microsoft/TypeScript/issues/41962).
When the host. isKnownTypesPackageName is undefined, languageService.getCodeFixesAtPosition will throw a error