### PR TITLE
substitute link in readme with absolute link to github

### DIFF
--- a/packages/ts-morph/readme.md
+++ b/packages/ts-morph/readme.md
@@ -12,7 +12,7 @@ Formerly `ts-simple-ast`.
 ## Overview
 
 - [Documentation](https://ts-morph.com/)
-- [Declaration file](lib/ts-morph.d.ts)
+- [Declaration file](https://github.com/dsherret/ts-morph/blob/latest/packages/ts-morph/lib/ts-morph.d.ts)
 
 ## Main Features
 


### PR DESCRIPTION
Hi,

I have discovered your package just recently (after fighting hard with the TS compiler API), I'd like to say I really appreciate your work! Excellent stuff, very usable, most interfaces I'd expect are just there … I hope I'll be using this package a lot in the future :) 

I realized that the "Declaration file" link [on npm](https://www.npmjs.com/package/ts-morph) is broken. Probably happened when switching to a monorepo setup?!
Anyway, I replaced it with an absolute link. Guess that will work in all cases.

Once again, thanks a lot for your great work! 