### PR TITLE
Expose `Project::options`

### DIFF
--- a/packages/ts-morph/src/Project.ts
+++ b/packages/ts-morph/src/Project.ts
@@ -65,7 +65,7 @@ export class Project {
      * Initializes a new instance.
      * @param options - Optional options.
      */
-    constructor(options: ProjectOptions = {}) {
+    constructor(readonly options: ProjectOptions = {}) {
         verifyOptions();
 
         // setup file system


### PR DESCRIPTION
I need to parse `tsconfig.json` to access a [`"deno2node"` top-level key](https://github.com/wojpawlik/deno2node/issues/4#issuecomment-826314717). This tiny change would save me from having to pass `tsConfigFilePath` alongside `project`.
